### PR TITLE
Qubes dwm with autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Install in Dom0:
 ```
 Dom0# qvm-run --pass-io <vmname> "cat /path/to/qubes-dwm/dwm/dwm" > /usr/local/bin/dwm
 Dom0# chmod u+x /usr/local/bin/dwm
+Dom0# qvm-run --pass-io <vmname> "cat /path/to/qubes-dwm/launchdwm" > /usr/local/bin/launchdwm
+Dom0# chmod u+x /usr/local/bin/launchdwm
 Dom0# qvm-run --pass-io <vmname> "cat /path/to/qubes-dwm/dwm.desktop" > /usr/share/xsessions/dwm.desktop
 ```
 

--- a/dwm.desktop
+++ b/dwm.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Name=dwm
-Exec=/usr/local/bin/dwm
+Exec=/usr/local/bin/launchdwm
 Type=XSession

--- a/launchdwm
+++ b/launchdwm
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+# launch qubes autostart programs
+autostart_etc=${XDG_CONFIG_DIRS-/etc/xdg}/autostart
+autostart_home=${XDG_CONFIG_HOME-~/.config}/autostart
+
+shopt -s nullglob
+for i in $autostart_etc/*.desktop $autostart_home/*.desktop; do
+    if ! grep -q "OnlyShowIn=" "$i"; then
+        $(grep "Exec=" "$i" | sed 's/Exec=//') &
+    fi
+done &
+
+# start dwm
+while xsetroot -name "`date` `uptime | sed 's/.*,//'`"
+do
+    sleep 1
+done &
+exec /usr/local/bin/dwm


### PR DESCRIPTION
Adds a script that will start autostart programs along with dwm. The script is called from the dwm.desktop file so it can be launched from the login screen (commits now signed :-)). 